### PR TITLE
[codex] Modernize Python compatibility, dependencies, tests, and docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,33 @@
+name: tests
+
+on:
+  push:
+    branches: ["main", "codex/**"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package + test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install .[dev]
+
+      - name: Run tests
+        run: |
+          python -m pytest --cov=quiche --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv*/
 env/
 venv/
 ENV/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+## Unreleased
+
+### Added
+- Modern test suite under `tests/` for import smoke, preprocessing, graph, metrics, and QUICHE smoke workflows.
+- GitHub Actions CI matrix for Python 3.10/3.11/3.12.
+- Migration report: `docs/migration-python-modernization.md`.
+
+### Changed
+- Packaging metadata modernized to PEP 621 in `pyproject.toml`.
+- Supported Python versions updated to `>=3.10,<3.13`.
+- Dependency model updated with extras: `plot`, `full`, `dev`.
+- Conda environment (`venv_quiche.yml`) updated for modern Python/scientific stack compatibility while keeping R support.
+
+### Fixed
+- Replaced bare `except:` handlers with explicit exceptions.
+- Fixed `compute_spatial_niches` khop parameter wiring (`k` vs `n_neighbors`).
+- Fixed obs alignment bug when filtering niche results.
+- Fixed chained assignment in niche annotation path.
+- Fixed undefined variable use in plotting default output path.
+- Improved optional dependency error messages for heavy workflows.

--- a/README.md
+++ b/README.md
@@ -16,33 +16,55 @@ This repo is currently under development as we are in the process of porting ove
 You can download all of the preprocessed MIBI-TOF datasets (`.h5ad` files) from the [Zenodo](https://zenodo.org/records/14290163) repository. Imaging data and cell segmentation masks can be found in the [BioStudies](https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BIAD1507) repository. 
 
 ## Installation
-You can clone the git repository by, 
+Supported Python versions: **3.10, 3.11, 3.12**.
+
+You can clone the git repository by,
 ```
 git clone https://github.com/jranek/quiche.git
 ```
-Then change the working directory as, 
+Then change the working directory as,
 ```
 cd quiche
 ```
 
-For installation, we recommend that you create a conda environment using the provided yml file.
+### Option 1: pip (recommended for Python-only workflows)
+Install core dependencies:
+```bash
+pip install .
+```
+
+Install optional extras:
+```bash
+# plotting helpers
+pip install .[plot]
+
+# full spatial/omics stack (scanpy/squidpy/pertpy/muon/sketchKH)
+pip install .[full]
+
+# development + test tooling
+pip install .[dev]
+```
+
+### Option 2: conda (recommended for R/edgeR workflows)
+Create the conda environment using the provided YAML file:
 
 ```
 conda env create -f venv_quiche.yml
 ```
 
-Once the environment is created, you can activate it by,
+Once the environment is created, activate it:
 ```
 conda activate venv_quiche
 ```
 
-In order to perform spatial enrichment analysis with QUICHE, you'll also need to install the necessary R packages. To do so, first open R in the terminal with the activated environment as, 
+The conda file includes the required R runtime and bridge packages (`r-base`, `rpy2`, `r-matrix`, `r-locfit`, `r-statmod`).
 
+If you need to install `edgeR` in that activated conda environment, open R:
 ```
 R
 ```
 
-Then install the packages as, 
+Then install:
 
 ```R
 if (!require("BiocManager", quietly = TRUE))
@@ -54,6 +76,15 @@ install.packages('statmod')
 #edger v3.40.2
 BiocManager::install("edgeR")
 ```
+
+### Quick smoke test
+```bash
+pytest tests/test_quiche_smoke.py -q
+```
+
+## Known limitations
+- Differential enrichment paths that use edgeR/pertpy require optional heavy dependencies (`.[full]`) and, for edgeR-based workflows, a working R setup.
+- `pip install .` intentionally does not install R/Rpy2 dependencies; use the conda environment when R-backed analysis is required.
 
 ## Example usage
 In the subsections below, we will walk through a simple example of how you can use QUICHE. For a more detailed tutorial, including the necessary plotting functions, please see the demo Jupyter notebook [here](https://github.com/jranek/quiche/blob/main/notebooks/demo.ipynb). 
@@ -105,4 +136,3 @@ quiche_op.annotate_niches(nlargest = 3, annotation_scheme = 'neighborhood', anno
 
 ## License
 This software is licensed under the MIT license (https://opensource.org/licenses/MIT).
-

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ QUICHE is a statistical differential abundance testing method that can be used t
 
 This repo is currently under development as we are in the process of porting over our existing code into this independent repository. In the meantime, you can access the code associated with the paper [here](https://github.com/angelolab/publications/tree/main/2024-Ranek_etal_QUICHE). 
 
+## Modernization summary (2026-02)
+The codebase has been modernized for current Python and packaging standards while preserving the public API (`quiche.pp`, `quiche.tl`, `quiche.pl`).
+
+- Python support updated to `3.10-3.12`.
+- Packaging metadata migrated to modern PEP 621 format in `pyproject.toml`.
+- Dependencies split into install extras:
+  - `.[plot]` for plotting dependencies
+  - `.[full]` for heavier spatial/omics workflows
+  - `.[dev]` for tests and development tooling
+- Optional heavy dependencies now fail with clear messages only when those specific workflows are used, instead of breaking base imports.
+- Compatibility fixes applied for older grammar-era patterns and runtime issues.
+- Automated tests and CI were added (GitHub Actions matrix for Python 3.10/3.11/3.12).
+
+For full migration details, see `docs/migration-python-modernization.md`.
+
 ## Data access
 You can download all of the preprocessed MIBI-TOF datasets (`.h5ad` files) from the [Zenodo](https://zenodo.org/records/14290163) repository. Imaging data and cell segmentation masks can be found in the [BioStudies](https://www.ebi.ac.uk/biostudies/bioimages/studies/S-BIAD1507) repository. 
 

--- a/docs/migration-python-modernization.md
+++ b/docs/migration-python-modernization.md
@@ -1,0 +1,90 @@
+# Python Modernization and Compatibility Migration
+
+## Overview
+This migration modernizes QUICHE for Python 3.10-3.12, updates packaging metadata, introduces dependency extras, hardens optional dependency handling, and adds automated tests/CI.
+
+## Goals
+- Remove Python-version and packaging friction from old metadata/pins.
+- Preserve existing public module paths and class/function names.
+- Keep heavy optional stacks optional (scanpy/squidpy/pertpy/muon/sketchKH and R/edgeR workflows).
+- Add reproducible validation through tests and CI.
+
+## What changed
+
+### 1) Packaging and dependency model
+Files:
+- `pyproject.toml`
+- `venv_quiche.yml`
+
+Changes:
+- Updated `requires-python` to `>=3.10,<3.13`.
+- Converted project metadata to modern PEP 621 style (`authors`, `[project.urls]`, explicit `dependencies`).
+- Added dependency extras:
+  - `plot`: plotting dependencies.
+  - `full`: heavy spatial/omics dependencies.
+  - `dev`: test/lint/type tooling.
+- Added pytest config in `pyproject.toml`.
+- Modernized conda environment pins for Python 3.10-3.12 compatibility.
+- Kept R dependencies in the conda environment (`r-base`, `rpy2`, related R libs).
+
+### 2) Compatibility and runtime safety refactors
+Files:
+- `src/quiche/__init__.py`
+- `src/quiche/plotting/__init__.py`
+- `src/quiche/preprocessing/utils.py`
+- `src/quiche/tools/graph.py`
+- `src/quiche/tools/metrics.py`
+- `src/quiche/tools/quiche.py`
+- `src/quiche/plotting/plot.py`
+
+Changes:
+- Replaced bare `except:` blocks with explicit handling.
+- Removed legacy boolean comparison patterns (`== True`).
+- Added optional dependency guards with actionable `ImportError` messages.
+- Fixed discovered runtime issues:
+  - `compute_spatial_niches(khop=...)` now calls `spatial_niches_khop` with `k=...` (correct parameter name).
+  - `compute_spatial_niches` now filters `self.adata` using `obs_names` alignment, avoiding index desynchronization.
+  - Fixed chained assignment in niche annotation updates.
+  - Fixed undefined `metric` variable in `plot_niches` default save path.
+  - Fixed `generate_colors` list-input handling.
+  - Fixed incorrect `compute_niche_metadata` call in plotting helper.
+- Added scanpy availability guard in differential-expression plotting.
+
+### 3) Tests and CI
+Files added:
+- `tests/conftest.py`
+- `tests/test_imports.py`
+- `tests/test_preprocessing.py`
+- `tests/test_graph.py`
+- `tests/test_metrics.py`
+- `tests/test_quiche_smoke.py`
+- `.github/workflows/tests.yml`
+
+Coverage of new tests:
+- import smoke tests for package/submodules.
+- preprocessing utilities and download workflow (network mocked).
+- graph utilities and optional dependency guards.
+- metrics computations and optional dependency guards.
+- QUICHE class smoke checks on synthetic data.
+
+CI:
+- GitHub Actions matrix on Python `3.10`, `3.11`, `3.12`.
+- Installs `.[dev]` and runs pytest with coverage output.
+
+## Verification results
+Local verification (Python 3.11):
+- `pytest -q`: **19 passed**.
+- `pytest --cov=quiche --cov-report=term-missing`: **19 passed**.
+
+Notes:
+- A pandas `FutureWarning` appears in one statistical helper due `groupby(...).size().unstack()` default behavior change in future pandas versions. This does not affect current correctness.
+
+## Backward compatibility notes
+- Public import paths are preserved (`quiche.pp`, `quiche.tl`, `quiche.pl`).
+- Heavy operations now fail fast with clear guidance if optional deps are missing, instead of failing at package import time.
+- `pip install .` remains lightweight and Python-focused.
+- R/edgeR workflows remain supported via the conda environment path.
+
+## Known limitations
+- Full differential enrichment/plotting workflows may require `.[full]` dependencies and R setup depending on solver/tooling used.
+- `pip install .` intentionally does not bundle R/Rpy2 runtime.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,26 +7,70 @@ name = "quiche"
 dynamic = ["version"]
 description = "Quantitative intercellular niche enrichment"
 readme = "README.md"
-requires-python = '>=3.7,<3.10'
-license='MIT'
-author='Jolene Ranek'
-author_email='ranekjs@gmail.com'
+requires-python = ">=3.10,<3.13"
+license = "MIT"
+authors = [
+  { name = "Jolene Ranek", email = "ranekjs@gmail.com" },
+]
+dependencies = [
+  "anndata>=0.10,<0.12",
+  "joblib>=1.3,<2",
+  "networkx>=3.1,<4",
+  "numba>=0.57,<0.62",
+  "numpy>=1.24,<2.2",
+  "pandas>=1.5,<2.3",
+  "requests>=2.31,<3",
+  "scikit-learn>=1.2,<1.8",
+  "scipy>=1.10,<1.16",
+  "statsmodels>=0.14,<0.15",
+  "tqdm>=4.66,<5",
+]
 
 classifiers = [
-    'Development Status :: 3 - Alpha',
-    'Intended Audience :: Science/Research',
-    'Topic :: Scientific/Engineering :: Bio-Informatics',
-    'License :: OSI Approved :: MIT License',
-    'Programming Language :: Python :: 3.7',
-    'Programming Language :: Python :: 3.8',
-    'Programming Language :: Python :: 3.9',
-    'Operating System :: OS Independent',
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
 ]
-urls.Source = "https://github.com/jranek/quiche"
-urls.Home-page = "https://github.com/jranek/quiche"
+
+[project.urls]
+Source = "https://github.com/jranek/quiche"
+Homepage = "https://github.com/jranek/quiche"
+
+[project.optional-dependencies]
+plot = [
+  "matplotlib>=3.8,<3.11",
+  "scikit-image>=0.22,<0.26",
+  "seaborn>=0.13,<0.14",
+]
+full = [
+  "muon>=0.1.7,<0.2",
+  "pertpy>=0.9,<0.11",
+  "python-igraph>=0.11,<0.12",
+  "scanpy>=1.10,<1.12",
+  "sketchKH>=0.1.2,<0.2",
+  "squidpy>=1.6,<2",
+  "tqdm-joblib>=0.0.4,<0.1",
+]
+dev = [
+  "build>=1.2,<2",
+  "mypy>=1.11,<2",
+  "pytest>=8,<9",
+  "pytest-cov>=5,<7",
+  "ruff>=0.6,<0.8",
+]
 
 [tool.hatch.version]
 source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/quiche"]
+
+[tool.pytest.ini_options]
+addopts = "-ra --strict-markers"
+testpaths = ["tests"]

--- a/src/quiche/__init__.py
+++ b/src/quiche/__init__.py
@@ -1,3 +1,9 @@
-from .import tools as tl
-from .import preprocessing as pp
-from .import plotting as pl
+from . import preprocessing as pp
+from . import tools as tl
+
+try:
+    from . import plotting as pl
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    pl = None
+
+__all__ = ["pp", "tl", "pl"]

--- a/src/quiche/plotting/__init__.py
+++ b/src/quiche/plotting/__init__.py
@@ -1,1 +1,15 @@
-from .plot import *
+_PLOT_IMPORT_ERROR = None
+
+try:
+    from .plot import *  # noqa: F401,F403
+except ImportError as exc:  # pragma: no cover - exercised in optional dependency environments
+    _PLOT_IMPORT_ERROR = exc
+    __all__ = []
+
+
+def __getattr__(name):
+    if _PLOT_IMPORT_ERROR is not None:
+        raise ImportError(
+            "Plotting dependencies are missing. Install quiche with the [plot] extra."
+        ) from _PLOT_IMPORT_ERROR
+    raise AttributeError(name)

--- a/src/quiche/plotting/plot.py
+++ b/src/quiche/plotting/plot.py
@@ -18,11 +18,16 @@ from typing import List, Union, Optional, Dict, Tuple
 from tqdm.auto import tqdm
 from skimage import io
 from skimage.segmentation import find_boundaries
-from matplotlib import cm, colors
+from matplotlib import cm
 from matplotlib.ticker import MaxNLocator
 import matplotlib.colors as mcolors
-import scanpy as sc
 import anndata
+
+try:
+    import scanpy as sc
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    sc = None
+
 sns.set_style('ticks')
 
 def generate_colors(cmap: str = "viridis",
@@ -32,7 +37,7 @@ def generate_colors(cmap: str = "viridis",
     if not isinstance(n_colors, int) or (n_colors < 2) or (n_colors > 6):
         raise ValueError("n_colors must be an integer between 2 and 6")
     if isinstance(cmap, list):
-        colors = [scalar_mappable.to_rgba(color, alpha=alpha) for color in cmap]
+        colors = [mcolors.to_rgba(color, alpha=alpha) for color in cmap]
     else:
         scalar_mappable = ScalarMappable(cmap=cmap)
         colors = scalar_mappable.to_rgba(range(n_colors), alpha=alpha).tolist()
@@ -104,7 +109,7 @@ def plot_niches(quiche_op,
     if isinstance(segmentation_directory, str):
         segmentation_directory = pathlib.Path(segmentation_directory)
     if save_directory is None:
-       save_directory = pathlib.Path(os.path.join('figures', metric))
+       save_directory = pathlib.Path(os.path.join('figures', 'niche_masks'))
     elif isinstance(save_directory, str):
         save_directory = pathlib.Path(save_directory)
     if not save_directory.exists():
@@ -288,10 +293,9 @@ def plot_niche_scores(quiche_op,
     if not hasattr(quiche_op, 'mdata'):
         raise AttributeError("Must run quiche first.")
     
-    try:
-        quiche_op.mdata['spatial_nhood'].obs[metric] = quiche_op.mdata['quiche'].var[metric].values
-    except:
+    if metric not in quiche_op.mdata['quiche'].var.columns:
         raise KeyError(f"{metric} is not a valid metric.")
+    quiche_op.mdata['spatial_nhood'].obs[metric] = quiche_op.mdata['quiche'].var[metric].values
 
     subset_mdata = quiche_op.mdata['spatial_nhood'][quiche_op.mdata['spatial_nhood'].obs.loc[:, annotation_key] == niche]
     cell_type_list = niche.split('__')
@@ -440,10 +444,9 @@ def beeswarm(quiche_op,
     except KeyError:
         raise RuntimeError(f"'{annotation_key}' not defined in nhood_adata.obs.")
 
-    try:
-        nhood_adata = nhood_adata[np.isin(nhood_adata.obs[annotation_key], niches)]  # Subsets data by niches of interest
-    except:
+    if niches is None:
         raise RuntimeError('Specify a list of niches to plot.')
+    nhood_adata = nhood_adata[np.isin(nhood_adata.obs[annotation_key], niches)]  # Subsets data by niches of interest
 
     try:
         nhood_adata.obs[logfc_key]
@@ -639,21 +642,20 @@ def beeswarm_proportion(quiche_op,
         except KeyError:
             raise RuntimeError(f"{annotation_key} not defined")
 
-        try:
-            if niche_metadata is None:
-                niche_metadata = qu.tl.compute_niche_metadata(mdata,
-                                                niches = niches,
-                                                annotation_key =annotation_key,
-                                                patient_key = patient_key,
-                                                condition_key = condition_key,
-                                                niche_threshold = 0,
-                                                condition_type  = 'binary',
-                                                metrics = ['logFC'])
-            
-            niches = list(set(niches).intersection(set(niche_metadata[annotation_key].unique()))) #ensures niches are in metadata and pass niche_threshold
-            nhood_adata = nhood_adata[np.isin(nhood_adata.obs[annotation_key], niches)] #subsets data by niches of interest
-        except:
-             raise RuntimeError(f'Specify a list of niches to plot.')
+        if niches is None:
+            raise RuntimeError('Specify a list of niches to plot.')
+        if niche_metadata is None:
+            niche_metadata = qu.tl.compute_niche_metadata(quiche_op,
+                                            niches = niches,
+                                            annotation_key =annotation_key,
+                                            patient_key = patient_key,
+                                            condition_key = condition_key,
+                                            niche_threshold = 0,
+                                            condition_type  = 'binary',
+                                            metrics = ['logFC'])
+
+        niches = list(set(niches).intersection(set(niche_metadata[annotation_key].unique()))) #ensures niches are in metadata and pass niche_threshold
+        nhood_adata = nhood_adata[np.isin(nhood_adata.obs[annotation_key], niches)] #subsets data by niches of interest
         
         try:
             nhood_adata.obs[logfc_key]
@@ -897,7 +899,7 @@ def plot_niche_network_donut(G: nx.Graph,
     """
     try:
         edge_cmap = cm.get_cmap(edge_cmap)
-    except:
+    except ValueError:
         raise ValueError(f"{edge_cmap} is not a valid cmap.")
 
     if node_order is None:
@@ -1036,7 +1038,7 @@ def plot_niche_network_donut(G: nx.Graph,
             )
             ax.add_patch(wedge)
         
-        if label_lineages == True:
+        if label_lineages:
             lineage_angles = {}
             for lineage in unique_lineages:
                 lineage_node_angles = [angles_per_node[node] for node in node_order if G.nodes[node]['lineage'] == lineage]
@@ -1126,6 +1128,11 @@ def plot_differential_expression(quiche_op,
     """    
     if not hasattr(quiche_op, 'adata_func'):
         raise AttributeError("Must run quiche_op.compute_functional_expression first.")
+    if sc is None:
+        raise ImportError(
+            "scanpy is required for plot_differential_expression. "
+            "Install quiche with the [full] extra."
+        )
     
     if markers is None:
         markers = quiche_op.mdata['expression'].var_names

--- a/src/quiche/preprocessing/utils.py
+++ b/src/quiche/preprocessing/utils.py
@@ -20,6 +20,8 @@ def make_directory(directory: str = None):
     Returns
     ----------
     """
+    if directory is None:
+        raise ValueError("directory must be provided.")
     if not os.path.exists(directory):
         os.makedirs(directory)
 
@@ -63,7 +65,8 @@ def create_single_positive_table(marker_vals: pd.DataFrame,
             contains the marker intensities as well as the single positive marker data
     """
     # create binary functional marker table, append to anndata table
-    for marker, threshold in threshold_list:
+    threshold_iter = threshold_list.items() if isinstance(threshold_list, dict) else threshold_list
+    for marker, threshold in threshold_iter:
         marker_vals[marker] = (marker_vals[marker].values >= threshold).astype('int')
 
     return marker_vals

--- a/src/quiche/tools/graph.py
+++ b/src/quiche/tools/graph.py
@@ -1,15 +1,34 @@
+from __future__ import annotations
+
+import logging
+from itertools import combinations
+from typing import Dict, Optional
+
+import anndata
 import numpy as np
 import pandas as pd
-import igraph as ig
 import scipy
-from sklearn.neighbors import NearestNeighbors
-from sklearn.decomposition import PCA
-import anndata
-import squidpy as sq
-import logging
 import networkx as nx
-from itertools import combinations
-from typing import Union, Optional, Dict
+from sklearn.decomposition import PCA
+from sklearn.neighbors import NearestNeighbors
+
+try:
+    import igraph as ig
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    ig = None
+
+try:
+    import squidpy as sq
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    sq = None
+
+
+def _require_dependency(dep, name: str):
+    if dep is None:
+        raise ImportError(
+            f"Optional dependency '{name}' is required for this method. "
+            "Install quiche with the [full] extra."
+        )
 
 def get_igraph(W: np.ndarray = None,
                directed: bool = None):
@@ -27,6 +46,7 @@ def get_igraph(W: np.ndarray = None,
     g: ig.Graph
         graph of adjacency matrix
     """
+    _require_dependency(ig, "python-igraph")
     sources, targets = W.nonzero()
     weights = W[sources, targets]
     if type(weights) == np.matrix:
@@ -46,7 +66,7 @@ def heat_kernel(dist: np.ndarray = None,
     ----------
     dist: np.ndarray (default = None)
         distance matrix (dimensions = cells x k)
-    radius: np.int (default = 3)
+    radius: int (default = 3)
         defines the per-cell bandwidth parameter (distance to the radius nn)
 
     Returns
@@ -173,10 +193,13 @@ def spatial_niches_khop(adata: anndata.AnnData,
                     niche_df_fov = pd.concat([niche_df_fov, niche_df_fov_], axis = 0)
             niche_df_fov.index = adata_fov.obs_names[~np.isin(adata_fov.obs_names, cells2remove)]
             niche_df.append(niche_df_fov)
-    try:
-        cells2remove = np.concatenate(cells2remove)    
-    except:
-        pass
+    flattened_cells2remove = []
+    for cell in cells2remove:
+        if isinstance(cell, (list, tuple, np.ndarray, pd.Index)):
+            flattened_cells2remove.extend(list(cell))
+        else:
+            flattened_cells2remove.append(cell)
+    cells2remove = np.array(flattened_cells2remove, dtype=object)
     niche_df = pd.concat(niche_df, axis = 0)
     niche_df = niche_df.fillna(0).copy()
     niche_df = niche_df.loc[adata.obs_names[~np.isin(adata.obs_names, list(set(cells2remove)))]]
@@ -300,11 +323,12 @@ def compute_spatial_neighbors(adata: anndata.AnnData,
     adata: anndata.AnnData
         annotated data object containing spatial proximity graph
     """
+    _require_dependency(sq, "squidpy")
     adata.obs[fov_key] = pd.Categorical(adata.obs[fov_key])
     if n_neighbors is not None:
         sq.gr.spatial_neighbors(adata, spatial_key = spatial_key, library_key = fov_key, n_neighs = n_neighbors, coord_type = coord_type)
         adata = bound_radius(adata, distances_key = 'spatial_distances', connectivities_key = 'spatial_connectivities', radius = radius)
-    elif delaunay == True:
+    elif delaunay:
         sq.gr.spatial_neighbors(adata, spatial_key = spatial_key, library_key = fov_key, delaunay = delaunay, coord_type = coord_type)
         adata = bound_radius(adata, distances_key = 'spatial_distances', connectivities_key = 'spatial_connectivities', radius = radius)
     else:

--- a/src/quiche/tools/metrics.py
+++ b/src/quiche/tools/metrics.py
@@ -1,15 +1,35 @@
-import pandas as pd
-import numpy as np
-import quiche as qu
-from sketchKH import sketch
 import anndata
-from muon import MuData
-import pertpy as pt
-import scanpy as sc
+import numpy as np
+import pandas as pd
+import quiche as qu
+from typing import Dict, List, Optional, Union
+
 from scipy.sparse import csr_matrix
-from statsmodels.stats.multitest import multipletests
 from scipy.stats import ranksums, spearmanr
-from typing import Union, Optional, Dict, List
+from statsmodels.stats.multitest import multipletests
+
+try:
+    from muon import MuData
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    MuData = None
+
+try:
+    import pertpy as pt
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    pt = None
+
+try:
+    import scanpy as sc
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    sc = None
+
+
+def _require_dependency(dep, name: str):
+    if dep is None:
+        raise ImportError(
+            f"Optional dependency '{name}' is required for this method. "
+            "Install quiche with the [full] extra."
+        )
 
 def compute_niche_composition(adata: anndata.AnnData,
                                 connectivities_key: str = 'spatial_connectivities',
@@ -71,7 +91,7 @@ def compute_niche_metadata(quiche_op,
                            condition_key: str = 'condition',
                            niche_threshold: int = 3,
                            condition_type: str = 'binary',
-                           metrics: Optional[List[str]] = ['logFC', 'SpatialFDR', 'PValue']):
+                           metrics: Optional[List[str]] = None):
     """
     Computes niche-level metadata.
 
@@ -111,6 +131,8 @@ def compute_niche_metadata(quiche_op,
                                                 metrics = ['logFC', 'SpatialFDR', 'PValue'])
     """
     mdata = quiche_op.mdata
+    if metrics is None:
+        metrics = ['logFC', 'SpatialFDR', 'PValue']
 
     for col in metrics:
         if col not in mdata['quiche'].var.columns:
@@ -251,6 +273,9 @@ def run_milo(adata: anndata.AnnData,
     mdata: mudata object
         annotated data object containing cell type abundance analysis
     """
+    _require_dependency(pt, "pertpy")
+    _require_dependency(sc, "scanpy")
+    _require_dependency(MuData, "muon")
     milo = pt.tl.Milo()
     mdata = milo.load(adata)
     sc.tl.pca(mdata[feature_key])

--- a/src/quiche/tools/quiche.py
+++ b/src/quiche/tools/quiche.py
@@ -1,21 +1,48 @@
-import pertpy as pt
-import pandas as pd
-import numpy as np
-from scipy.sparse import csr_matrix
-import anndata
-import quiche as qu
-from sketchKH import sketch
 import logging
-from muon import MuData
+from contextlib import nullcontext
+from typing import List, Optional, Union
+
+import anndata
+import numpy as np
+import pandas as pd
+import quiche as qu
 from joblib import Parallel, delayed
 from numba import njit
-from sklearn.base import BaseEstimator
 from pandas.api.types import is_numeric_dtype
-from tqdm_joblib import tqdm_joblib
+from scipy.sparse import csr_matrix
+from sklearn.base import BaseEstimator
 from tqdm import tqdm
-from typing import List, Optional, Union
+
+try:
+    import pertpy as pt
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    pt = None
+
+try:
+    from muon import MuData
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    MuData = None
+
+try:
+    from sketchKH import sketch
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    sketch = None
+
+try:
+    from tqdm_joblib import tqdm_joblib
+except ImportError:  # pragma: no cover - exercised in optional dependency environments
+    tqdm_joblib = None
+
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def _require_dependency(dep, name: str):
+    if dep is None:
+        raise ImportError(
+            f"Optional dependency '{name}' is required for this method. "
+            "Install quiche with the [full] extra."
+        )
 
 @njit
 def compute_avg_abundance(neighbor_indices, abundance_matrix):
@@ -190,11 +217,12 @@ class QUICHE(BaseEstimator):
         """
         logger.info('Computing spatial niches...')
         if khop is not None:
+            k_neighbors = 10 if n_neighbors is None else n_neighbors
             niche_df, _ = qu.tl.spatial_niches_khop(
                 self.adata,
                 radius = radius,
                 p = p,
-                n_neighbors = n_neighbors,
+                k = k_neighbors,
                 khop = khop,
                 min_cell_threshold = min_cell_threshold,
                 labels_key = self.labels_key,
@@ -221,9 +249,10 @@ class QUICHE(BaseEstimator):
                 min_cell_threshold = min_cell_threshold
             )
 
-        non_zero_indices = np.where(pd.DataFrame(self.adata_niche.X).sum(1) != 0)[0]
-        self.adata_niche = self.adata_niche[non_zero_indices, :].copy()
-        self.adata = self.adata[non_zero_indices, :].copy()
+        niche_totals = np.asarray(self.adata_niche.X.sum(axis=1)).ravel()
+        non_zero_mask = niche_totals != 0
+        self.adata_niche = self.adata_niche[non_zero_mask, :].copy()
+        self.adata = self.adata[self.adata_niche.obs_names, :].copy()
 
     def subsample(
         self,
@@ -265,6 +294,7 @@ class QUICHE(BaseEstimator):
             logger.info('Skipping distribution-focused downsampling.')
             self.adata_niche_subsample = self.adata_niche
         else:
+            _require_dependency(sketch, "sketchKH")
             logger.info('Performing distribution-focused downsampling...')
             _, self.adata_niche_subsample = sketch(
                 self.adata_niche,
@@ -329,6 +359,7 @@ class QUICHE(BaseEstimator):
             model_contrasts = model_contrasts,
             solver = solver
         )
+        _require_dependency(MuData, "muon")
         self.mdata = MuData({'expression': self.adata, 'spatial_nhood': self.mdata['spatial_nhood'], 'quiche': self.mdata['milo']})
         self.mdata['quiche'].var.loc[:, ['-log10(SpatialFDR)', '-log10(PValue)']] = -1*np.log10(self.mdata['quiche'].var.loc[:, ['SpatialFDR', 'PValue']]).values
         self.mdata['quiche'].var[self.mdata['spatial_nhood'].obs.columns] = self.mdata['spatial_nhood'].obs.values
@@ -356,6 +387,7 @@ class QUICHE(BaseEstimator):
         mdata: MuData
             annotated data object after differential analysis.
         """
+        _require_dependency(pt, "pertpy")
         milo = pt.tl.Milo()
         mdata = milo.load(self.adata_niche_subsample, feature_key='spatial_nhood')
         mdata['spatial_nhood'].uns["nhood_neighbors_key"] = None
@@ -422,10 +454,9 @@ class QUICHE(BaseEstimator):
         self.mdata['quiche'].var[annotation_key] = annotations
         self.mdata['spatial_nhood'].obs[annotation_key] = annotations
 
-        try:
-            self.mdata['quiche'].var[annotation_key].loc[np.isin(self.mdata['quiche'].var['index_cell'], self.cells_nonn)] = 'unidentified'
-        except:
-            pass
+        if self.cells_nonn is not None and 'index_cell' in self.mdata['quiche'].var.columns:
+            mask = np.isin(self.mdata['quiche'].var['index_cell'], self.cells_nonn)
+            self.mdata['quiche'].var.loc[mask, annotation_key] = 'unidentified'
 
     def compute_niche_abundance_neighborhood(
         self,
@@ -619,8 +650,11 @@ class QUICHE(BaseEstimator):
 
         total_niches = len(nn_array)
 
-        with tqdm_joblib(tqdm(total=total_niches, desc="Computing Functional Expression")):
+        progress = tqdm(total=total_niches, desc="Computing Functional Expression")
+        context_manager = tqdm_joblib(progress) if tqdm_joblib is not None else nullcontext()
+        with context_manager:
             func_results = Parallel(n_jobs=n_jobs, backend='threading')(delayed(process_niche)(i) for i in range(total_niches))
+        progress.close()
 
         func_arr = [df for sublist in func_results for df in sublist]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+import numpy as np
+import pandas as pd
+import anndata
+import pytest
+
+
+@pytest.fixture
+def synthetic_adata() -> anndata.AnnData:
+    n_cells = 12
+    x = np.random.default_rng(0).normal(size=(n_cells, 4)).astype(float)
+    obs = pd.DataFrame(
+        {
+            "cell_cluster": pd.Categorical(
+                ["A", "B", "C", "A", "B", "C", "A", "B", "C", "A", "B", "C"]
+            ),
+            "fov": pd.Categorical(["fov1"] * 6 + ["fov2"] * 6),
+            "Patient_ID": ["p1"] * 6 + ["p2"] * 6,
+            "label": [str(i + 1) for i in range(n_cells)],
+            "condition": ["0"] * 6 + ["1"] * 6,
+        },
+        index=[f"cell_{i}" for i in range(n_cells)],
+    )
+
+    adata = anndata.AnnData(x, obs=obs)
+    adata.obsm["spatial"] = np.random.default_rng(1).uniform(0, 100, size=(n_cells, 2))
+    return adata

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,39 @@
+import numpy as np
+import scipy.sparse as sp
+import pytest
+
+from quiche.tools import graph
+
+
+def test_construct_affinity_shape_and_symmetry():
+    x = np.random.default_rng(2).normal(size=(10, 4))
+    w = graph.construct_affinity(x, k=3, radius=1)
+    assert w.shape == (10, 10)
+    np.testing.assert_allclose((w - w.T).toarray(), np.zeros((10, 10)), atol=1e-8)
+
+
+def test_get_igraph_requires_optional_dependency(monkeypatch):
+    monkeypatch.setattr(graph, "ig", None)
+    with pytest.raises(ImportError, match="python-igraph"):
+        graph.get_igraph(sp.csr_matrix(np.eye(3)), directed=False)
+
+
+def test_compute_spatial_neighbors_requires_squidpy(monkeypatch, synthetic_adata):
+    monkeypatch.setattr(graph, "sq", None)
+    with pytest.raises(ImportError, match="squidpy"):
+        graph.compute_spatial_neighbors(synthetic_adata)
+
+
+def test_spatial_niches_khop_runs(synthetic_adata):
+    niche_df, nn_dict = graph.spatial_niches_khop(
+        synthetic_adata,
+        radius=1000,
+        k=2,
+        khop=2,
+        labels_key="cell_cluster",
+        spatial_key="spatial",
+        fov_key="fov",
+        min_cell_threshold=1,
+    )
+    assert not niche_df.empty
+    assert set(nn_dict.keys()) == {"fov1", "fov2"}

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,13 @@
+import importlib
+
+
+def test_import_quiche_root():
+    quiche = importlib.import_module("quiche")
+    assert hasattr(quiche, "pp")
+    assert hasattr(quiche, "tl")
+
+
+def test_import_quiche_submodules():
+    importlib.import_module("quiche.preprocessing")
+    importlib.import_module("quiche.tools")
+    importlib.import_module("quiche.plotting")

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+import anndata
+import pytest
+
+from quiche.tools import metrics
+
+
+class DummyQuicheOp:
+    def __init__(self, mdata):
+        self.mdata = mdata
+
+
+def _build_quiche_var_adata() -> anndata.AnnData:
+    adata = anndata.AnnData(np.zeros((1, 6)))
+    adata.var = pd.DataFrame(
+        {
+            "quiche_niche_neighborhood": ["A__B", "A__B", "B__C", "B__C", "A__B", "B__C"],
+            "Patient_ID": ["p1", "p2", "p1", "p2", "p3", "p3"],
+            "condition": ["0", "1", "0", "1", "0", "1"],
+            "logFC": [1.0, 0.8, -1.1, -0.9, 1.2, -1.0],
+            "SpatialFDR": [0.01, 0.02, 0.03, 0.04, 0.03, 0.01],
+            "PValue": [0.02, 0.03, 0.01, 0.05, 0.04, 0.02],
+        },
+        index=[f"n{i}" for i in range(6)],
+    )
+    return adata
+
+
+def test_compute_niche_composition(synthetic_adata):
+    n = synthetic_adata.n_obs
+    connectivities = sp.csr_matrix(np.eye(n))
+    synthetic_adata.obsp["spatial_connectivities"] = connectivities
+    adata_niche, cells_nonn = metrics.compute_niche_composition(
+        synthetic_adata,
+        connectivities_key="spatial_connectivities",
+        labels_key="cell_cluster",
+        min_cell_threshold=1,
+    )
+    assert adata_niche.n_obs == n
+    assert isinstance(cells_nonn, list)
+
+
+def test_compute_niche_metadata_and_filter_niches():
+    quiche_adata = _build_quiche_var_adata()
+    op = DummyQuicheOp({"quiche": quiche_adata})
+
+    niche_df = metrics.compute_niche_metadata(
+        op,
+        annotation_key="quiche_niche_neighborhood",
+        patient_key="Patient_ID",
+        condition_key="condition",
+        niche_threshold=0,
+        metrics=["logFC", "SpatialFDR", "PValue"],
+    )
+    assert not niche_df.empty
+    assert "proportion_patients_niche" in niche_df.columns
+
+    scores_df = metrics.filter_niches(
+        op,
+        thresholds={"logFC": {"median": [-0.5, 0.5]}, "SpatialFDR": {"median": 0.05}},
+        min_niche_count=1,
+        annotation_key="quiche_niche_neighborhood",
+    )
+    assert isinstance(scores_df, pd.DataFrame)
+
+
+def test_run_milo_requires_optional_dependencies(monkeypatch, synthetic_adata):
+    monkeypatch.setattr(metrics, "pt", None)
+    with pytest.raises(ImportError, match="pertpy"):
+        metrics.run_milo(synthetic_adata)
+
+
+def test_differential_cell_type_abundance_binary(synthetic_adata):
+    condition_dict = {"p1": "0", "p2": "1"}
+    norm_counts, results_df = metrics.differential_cell_type_abundance(
+        synthetic_adata,
+        condition_dict=condition_dict,
+        patient_key="Patient_ID",
+        labels_key="cell_cluster",
+        condition_key="condition",
+        condition_type="binary",
+        id1="0",
+        id2="1",
+    )
+    assert "FDR_p_value" in results_df.columns
+    assert "Patient_ID" in norm_counts.columns

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from quiche.preprocessing import utils
+
+
+def test_standardize_center_and_scale():
+    x = np.array([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    out = utils.standardize(x)
+    np.testing.assert_allclose(out.mean(axis=0), [0.0, 0.0], atol=1e-7)
+    np.testing.assert_allclose(out.std(axis=0), [1.0, 1.0], atol=1e-7)
+
+
+def test_filter_fovs_filters_small_groups(synthetic_adata):
+    filtered = utils.filter_fovs(synthetic_adata, patient_key="Patient_ID", threshold=7)
+    assert filtered.n_obs == 0
+
+
+def test_make_directory_requires_path():
+    with pytest.raises(ValueError, match="directory must be provided"):
+        utils.make_directory(None)
+
+
+def test_create_single_positive_table_accepts_dict():
+    marker_vals = pd.DataFrame({"m1": [0.1, 0.7], "m2": [0.8, 0.2]})
+    threshold_list = {"m1": 0.5, "m2": 0.5}
+    out = utils.create_single_positive_table(marker_vals.copy(), threshold_list)
+    assert out["m1"].tolist() == [0, 1]
+    assert out["m2"].tolist() == [1, 0]
+
+
+def test_download_data_writes_file(monkeypatch, tmp_path: Path):
+    class DummyResponse:
+        headers = {"Content-Length": "4"}
+
+        def raise_for_status(self):
+            return None
+
+        def iter_content(self, chunk_size=1024):
+            yield b"ab"
+            yield b"cd"
+
+    def fake_get(url, stream=True, headers=None):
+        assert "example_id.h5ad?download=1" in url
+        return DummyResponse()
+
+    monkeypatch.setattr(utils.requests, "get", fake_get)
+
+    utils.download_data(
+        id="example_id",
+        base_url="https://example.org/files",
+        dest_str=str(tmp_path),
+        overwrite=True,
+    )
+
+    out_file = tmp_path / "example_id.h5ad"
+    assert out_file.exists()
+    assert out_file.read_bytes() == b"abcd"

--- a/tests/test_quiche_smoke.py
+++ b/tests/test_quiche_smoke.py
@@ -1,0 +1,34 @@
+import pytest
+
+from quiche.tools.quiche import QUICHE
+import quiche.tools.quiche as quiche_module
+
+
+def test_quiche_init_requires_keys(synthetic_adata):
+    bad = synthetic_adata.copy()
+    bad.obs = bad.obs.drop(columns=["cell_cluster"])
+    with pytest.raises(KeyError, match="cell_cluster"):
+        QUICHE(bad)
+
+
+def test_quiche_compute_spatial_niches_khop_smoke(synthetic_adata):
+    op = QUICHE(synthetic_adata)
+    op.compute_spatial_niches(radius=1000, n_neighbors=2, khop=2, min_cell_threshold=1)
+    assert op.adata_niche is not None
+    assert op.adata_niche.n_obs > 0
+
+
+def test_quiche_subsample_requires_sketch_when_requested(monkeypatch, synthetic_adata):
+    op = QUICHE(synthetic_adata)
+    op.compute_spatial_niches(radius=1000, n_neighbors=2, khop=2, min_cell_threshold=1)
+    monkeypatch.setattr(quiche_module, "sketch", None)
+    with pytest.raises(ImportError, match="sketchKH"):
+        op.subsample(sketch_size=2)
+
+
+def test_quiche_da_requires_pertpy(synthetic_adata, monkeypatch):
+    op = QUICHE(synthetic_adata)
+    op.adata_niche_subsample = synthetic_adata.copy()
+    monkeypatch.setattr(quiche_module, "pt", None)
+    with pytest.raises(ImportError, match="pertpy"):
+        op.quicheDA()

--- a/venv_quiche.yml
+++ b/venv_quiche.yml
@@ -4,35 +4,34 @@ channels:
     - conda-forge
     - defaults
 dependencies:
-    - anndata>=0.7.6,<0.10.9
-    - umap-learn==0.5.1
-    - scikit-learn>=0.23.2
-    - scikit-image>=0.19.2
-    - python>=3.7
+    - python>=3.10,<3.13
+    - anndata>=0.10,<0.12
+    - numpy>=1.24
+    - pandas>=1.5
+    - scipy>=1.10
+    - scikit-learn>=1.2
+    - statsmodels>=0.14
+    - networkx>=3.1
+    - numba>=0.57
+    - requests>=2.31
+    - tqdm>=4.66
+    - matplotlib>=3.8
+    - seaborn>=0.13
+    - scikit-image>=0.22
+    - scanpy>=1.10,<1.12
+    - python-igraph>=0.11
+    - squidpy>=1.6
     - ipython
     - ipykernel
-    - networkx==2.7
-    - statsmodels>=0.12.2
-    - scanpy>=1.8.1
-    - python-igraph>=0.9.6
-    - seaborn>=0.12.2
-    - numba>=0.53.0
-    - tqdm
     - pip
-    - r==4.3
+    - r-base=4.3
     - r-matrix
     - r-locfit
     - r-statmod
-    - rpy2==3.5.11
-    - scipy==1.12.0
-    - shapely
-    - numpy==1.23.4
+    - rpy2>=3.5
     - pip:
-        - sketchKH==0.1.2
-        - squidpy>=1.6.1
-        - pertpy
-        - flax==0.7.4
-        - jax==0.4.13
-        - jaxlib==0.4.13
-        - chex==0.1.8
+        - sketchKH>=0.1.2,<0.2
+        - muon>=0.1.7,<0.2
+        - pertpy>=0.9,<0.11
+        - tqdm-joblib>=0.0.4,<0.1
         - .


### PR DESCRIPTION
## Summary
This PR modernizes QUICHE for current Python tooling while preserving the existing public API surface (`quiche.pp`, `quiche.tl`, `quiche.pl`) and stabilizing install/test workflows.

It addresses compatibility and maintenance pain points caused by old grammar-era packaging metadata, outdated pins, and eager imports of heavy optional dependencies.

## Problem and user impact
Before this change:
- Project metadata used legacy fields and did not declare runtime dependencies in `pyproject.toml`.
- Python support targeted only 3.7-3.9.
- Import/runtime paths could fail early when optional heavy dependencies were not installed.
- No automated test suite or CI matrix existed to protect compatibility changes.

This made installation brittle, especially for users on modern Python versions, and increased regression risk.

## Root causes
- Packaging configuration was incomplete for modern PEP 621 workflows.
- Optional stacks (scanpy/squidpy/pertpy/muon/sketchKH/R-driven workflows) were imported eagerly.
- A few runtime bugs (parameter mismatch and row-alignment issues) were hidden due limited test coverage.

## What this PR changes
### 1) Packaging and dependency modernization
- Modernized `pyproject.toml` metadata to PEP 621 format.
- Declared explicit runtime dependencies.
- Set supported Python range to `>=3.10,<3.13`.
- Added extras:
  - `plot`
  - `full`
  - `dev`
- Updated `venv_quiche.yml` to align with Python 3.10-3.12 and modern stack versions.
- Kept R dependencies in conda for edgeR/R workflows.

### 2) Compatibility and correctness fixes (API-preserving)
- Replaced bare `except:` handlers with explicit handling.
- Removed outdated boolean-style checks.
- Added optional dependency guards with actionable ImportErrors.
- Fixed concrete runtime bugs:
  - `compute_spatial_niches(khop=...)` now passes `k` correctly.
  - `compute_spatial_niches` now preserves row alignment via `obs_names`.
  - Fixed chained assignment in annotation update path.
  - Fixed undefined `metric` variable in plotting defaults.
  - Fixed list-color handling in `generate_colors`.
  - Fixed incorrect call-site argument in plotting metadata helper.

### 3) Test suite + CI
- Added `tests/` with deterministic synthetic fixtures and coverage for:
  - imports
  - preprocessing
  - graph helpers
  - metrics helpers
  - QUICHE smoke paths
- Added GitHub Actions matrix for Python 3.10/3.11/3.12.

### 4) Documentation
- Updated README installation guidance for pip extras and conda/R workflows.
- Added quick smoke-test command.
- Added known limitations for heavy optional stacks.
- Added migration report and changelog entry.

## Validation performed
Local validation on Python 3.11:
- `pytest -q` -> 19 passed
- `pytest --cov=quiche --cov-report=term-missing` -> 19 passed

(One pandas FutureWarning remains in an existing statistical helper; behavior is unaffected.)

## Backward compatibility statement
- Public module/function/class import paths are preserved.
- Heavy optional workflows now fail fast with clear install guidance instead of breaking base imports.
- `pip install .` stays lightweight; conda remains the recommended route for R-backed analysis.

## Commit structure
- `packaging/deps: modernize metadata and env`
- `code-compat: guard optional deps and fix runtime bugs`
- `tests-ci: add synthetic tests and py3.10-3.12 matrix`
- `docs: document migration, install paths, and limits`
